### PR TITLE
Simplifies GET filtering

### DIFF
--- a/test_hammock.py
+++ b/test_hammock.py
@@ -51,6 +51,14 @@ class TestCaseWrest(unittest.TestCase):
             self.assertIsNotNone(resp.json.get('method', None))
             self.assertEqual(resp.json.get('method').lower(), method)
 
+    def test_GET_filters(self):
+        client = Hammock(BASE_URL)
+        resp = client.GET(filter=12)
+        self.assertEqual(resp.json['querystring'], 'filter=12')
+        self.assertRaises(Exception, lambda: client.GET(filter=12, timeout=14))
+        resp = client.GET(filter=12, foo="bar")
+        self.assertEqual(resp.json['querystring'], 'filter=12&foo=bar')
+
     def test_urls(self):
         client = Hammock(BASE_URL)
         combs = [


### PR DESCRIPTION
Hi @kadirpekel,

First, I would like to congratulate you with hammock. It's simple/beautiful and has magic where it should have it.

I'm not sure if you've heard of <a href="https://github.com/dstufft/slumber">slumber</a>. I recently found hammock and I've decided porting slumber code to hammock. It's quite a plug and play process.

One of the things I did like from slumber that could be arguable, is the way you could pass GET parameters. This patch allows the same type of syntax:

```
api.resource.GET(foo='bar')
```

Only non special requests keyword arguments are allowed this way. So you cannot merge both, for example, this raises an `Exception`:

```
api.resource.GET(foo='bar', timeout=12)
```

`timeout` as you know is a special requests parameter. This eases portability, covers a very common case, for which is nice to have a simplified syntax.

Cheers,
Miguel
