### PR TITLE
Adding append_slash option to Hammock

### DIFF
--- a/test_hammock.py
+++ b/test_hammock.py
@@ -69,6 +69,23 @@ class TestCaseWrest(unittest.TestCase):
             self.assertIsNotNone(resp.json.get('path', None))
             self.assertEqual(resp.json.get('path'), PATH)
 
+        client = Hammock(BASE_URL, append_slash=True)
+        combs = [
+            client.sample.path.to.resource,
+            client('sample').path('to').resource,
+            client('sample', 'path', 'to', 'resource'),
+            client('sample')('path')('to')('resource'),
+            client.sample('path')('to', 'resource'),
+            client('sample', 'path',).to.resource
+        ]
+
+        for comb in combs:
+            self.assertEqual(str(comb), URL + '/')
+            resp = comb.GET()
+            self.assertIsNotNone(resp.json)
+            self.assertIsNotNone(resp.json.get('path', None))
+            self.assertEqual(resp.json.get('path'), PATH + '/')
+
     def test_body(self):
         client = Hammock(BASE_URL)
         body = "body fixture"


### PR DESCRIPTION
Adds a flag to add an slash to the url, this is necessary for some APIs, defaults to `False` for backwards compatibility.

Cheers,
Miguel
