### PR TITLE
Fixing inheritance and chaining

### DIFF
--- a/hammock.py
+++ b/hammock.py
@@ -22,7 +22,12 @@ class Hammock(object):
         """Here comes some magic. Any absent attribute typed within class
         falls here and return a new child `Hammock` instance in the chain.
         """
-        return Hammock(name=name, parent=self)
+        chain = self.__class__(name=name, parent=self)
+        for attribute, value in self.__dict__.items():
+            if attribute not in ('_name', '_parent'):
+               setattr(chain, attribute, value)
+
+        return chain
 
     def __iter__(self):
         """Iterator implementation which iterates over `Hammock` chain."""
@@ -40,7 +45,11 @@ class Hammock(object):
         """
         chain = self
         for arg in args:
-            chain = Hammock(name=str(arg), parent=chain)
+            chain = self.__class__(name=str(arg), parent=chain)
+        for attribute, value in self.__dict__.items():
+            if attribute not in ('_name', '_parent'):
+                setattr(chain, attribute, value)
+
         return chain
 
     def _probe_session(self):
@@ -90,6 +99,7 @@ def bind_method(method):
         session = hammock._probe_session() or requests
         return session.request(method, hammock._url(*args), **kwargs)
     return aux
+
 
 for method in Hammock.HTTP_METHODS:
     setattr(Hammock, method.upper(), bind_method(method))

--- a/test_hammock.py
+++ b/test_hammock.py
@@ -96,6 +96,26 @@ class TestCaseWrest(unittest.TestCase):
         self.assertIsNotNone(headers.get('HTTP_FOO', None))
         self.assertEqual(headers.get('HTTP_FOO'), 'bar')
 
+    def test_inheritance(self):
+        class CustomHammock(Hammock):
+            def __init__(self, name=None, parent=None, **kwargs):
+                if 'testing' in kwargs:
+                    self.testing = kwargs.pop('testing')
+                super(CustomHammock, self).__init__(name, parent, **kwargs)
+
+            def _url(self, *args):
+                assert isinstance(self.testing, bool)
+                global called
+                called = True
+                return super(CustomHammock, self)._url(*args)
+
+        global called
+        called = False
+        client = CustomHammock(BASE_URL, testing=True)
+        resp = client.sample.path.to.GET()
+        self.assertEqual(resp.json['path'], '/sample/path/to')
+        self.assertTrue(called)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- If we subclass `Hammock`, we won't get subclass methods called, because chaining magic returns a `Hammock` instance, while it should return a `self.__class__` instance.
- On the other hand, if we set attributes in our subclass constructor, when chaining they get lost.

I've added a test case for both problems. This patch fixes the issues.

Cheers,
Miguel
