### PR TITLE
Moving HTTP request code to a Hammock method

### DIFF
--- a/hammock.py
+++ b/hammock.py
@@ -82,14 +82,21 @@ class Hammock(object):
         """ String representaion of current `Hammock` chain"""
         return self._url()
 
+    def _request(self, method, *args, **kwargs):
+        """
+        Makes the HTTP request using requests module
+        """
+        session = self._probe_session() or requests
+        return session.request(method, self._url(*args), **kwargs)
+
 
 def bind_method(method):
     """Bind `requests` module HTTP verbs to `Hammock` class as
     static methods."""
     def aux(hammock, *args, **kwargs):
-        session = hammock._probe_session() or requests
-        return session.request(method, hammock._url(*args), **kwargs)
+        return hammock._request(method, *args, **kwargs)
     return aux
+
 
 for method in Hammock.HTTP_METHODS:
     setattr(Hammock, method.upper(), bind_method(method))


### PR DESCRIPTION
This allows to override it easily, some times we might not want to use requests. Like when using hammock for Django testing, where we should be using Django's testing client.

I would also love to contribute a subclass of `Hammock` that we use for this situation, using hammock with Django testing client. How about a gist and linking it from the README?

Cheers,
Miguel
