### PR TITLE
Allow for ignored components

### DIFF
--- a/hammock.py
+++ b/hammock.py
@@ -7,7 +7,7 @@ class Hammock(object):
 
     HTTP_METHODS = ['get', 'options', 'head', 'post', 'put', 'patch', 'delete']
 
-    def __init__(self, name=None, parent=None, append_slash=False, **kwargs):
+    def __init__(self, name=None, parent=None, append_slash=False, ignore=(), **kwargs):
         """Constructor
 
         Arguments:
@@ -19,6 +19,7 @@ class Hammock(object):
         self._name = name
         self._parent = parent
         self._append_slash = append_slash
+        self._ignore = ignore
         self._session = kwargs and requests.session(**kwargs) or requests
 
     def _spawn(self, name):
@@ -56,7 +57,7 @@ class Hammock(object):
             *args -- array of string representable objects
         """
         chain = self
-        for arg in args:
+        for arg in filter(lambda x: x not in self._ignore, args):
             chain = chain._spawn(str(arg))
         return chain
 

--- a/test_hammock.py
+++ b/test_hammock.py
@@ -72,6 +72,24 @@ class TestCaseWrest(unittest.TestCase):
             self.assertIsNotNone(resp.json.get('path', None))
             self.assertEqual(resp.json.get('path'), PATH)
 
+    def test_urls_ignore(self):
+        client = Hammock(BASE_URL, ignore=(False, None))
+        combs = [
+            client.sample(False).path.to(None).resource,
+            client('sample', False).path('to', None).resource,
+            client('sample', False, 'path', 'to', None, 'resource'),
+            client('sample')(False)('path')('to')(None)('resource'),
+            client.sample(False, 'path')('to', None, 'resource'),
+            client('sample', False, 'path',).to(None).resource
+        ]
+
+        for comb in combs:
+            self.assertEqual(str(comb), URL)
+            resp = comb.GET()
+            self.assertIsNotNone(resp.json)
+            self.assertIsNotNone(resp.json.get('path', None))
+            self.assertEqual(resp.json.get('path'), PATH)
+
     def test_append_slash_option(self):
         client = Hammock(BASE_URL, append_slash=True)
         resp = client.sample.path.to.resource.GET()


### PR DESCRIPTION
Hi, this is a patch that allows to strip out specific uri components passed to **call**().
This is util where non-validated data is used to build some url but it is ok if missing.

Silly example:

<pre>
 >>> h=hammock.Hammock('http://url.com', ignore=(False,None))
 >>> h.goodbye(True, False).cruel(None).world.False
 http://url.com/goodbye/True/cruel/world/False
</pre>
