### PR TITLE
Support of requests>=1.0.0

### DIFF
--- a/hammock.py
+++ b/hammock.py
@@ -19,7 +19,10 @@ class Hammock(object):
         self._name = name
         self._parent = parent
         self._append_slash = append_slash
-        self._session = kwargs and requests.session(**kwargs) or requests
+        self._session = requests.session()
+        for attr, value in kwargs.items():
+            setattr(self._session, attr, value)
+
 
     def _spawn(self, name):
         """Returns a shallow copy of current `Hammock` instance as nested child

--- a/test_hammock.py
+++ b/test_hammock.py
@@ -71,6 +71,14 @@ class TestCaseWrest(unittest.TestCase):
         self.assertTrue(called)
         self.assertEqual(HTTPretty.last_request.path, self.PATH)
 
+    @httprettified
+    def test_requests_kwargs(self):
+        """Test conformity with new requests API"""
+        HTTPretty.register_uri(HTTPretty.GET, self.URL)
+        client = Hammock(self.BASE_URL, params={'foo': 'bar'})
+        resp = client.sample.path.to.resource.GET()
+        self.assertEqual(HTTPretty.last_request.path, '/sample/path/to/resource?foo=bar')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Session object does not accept kwargs anymore.
