### PR TITLE
request.session should not be taking kwargs

### DIFF
--- a/hammock.py
+++ b/hammock.py
@@ -19,7 +19,7 @@ class Hammock(object):
         self._name = name
         self._parent = parent
         self._append_slash = append_slash
-        self._session = kwargs and requests.session(**kwargs) or requests
+        self._session = kwargs and requests.session() or requests
 
     def _spawn(self, name):
         """Returns a shallow copy of current `Hammock` instance as nested child


### PR DESCRIPTION
request.session() which refers to 

def session():
    """Returns a :class:`Session` for context-management."""
    return Session()

does not taking any values so i think request.session() shouldn't be taking keyword arguments. Getting "TypeError: session() takes no arguments (1 given)" when used with kwargs...
