### PR TITLE
support new requests session API

### DIFF
--- a/hammock.py
+++ b/hammock.py
@@ -19,7 +19,25 @@ class Hammock(object):
         self._name = name
         self._parent = parent
         self._append_slash = append_slash
-        self._session = kwargs and requests.session(**kwargs) or requests
+        self._session = requests
+        if kwargs:
+            # update requests.session with whatever is passed on kwargs
+            self._session = requests.session()
+            for attr, value in kwargs.items():
+                try:
+                    _attr = getattr(self._session, attr)
+                    if hasattr(_attr, '__setitem__'):
+                        # user supplied a mapping object
+                        if not hasattr(value, '__setitem__'):
+                            raise ValueError(attr)
+                        def _set(k, v): _attr[k] = v
+                        map(lambda (k,v): _set(k,v), value.iteritems())
+                    else:
+                        setattr(self._session, attr, value)
+                except AttributeError:
+                    setattr(self._session, attr, value)
+
+
 
     def _spawn(self, name):
         """Returns a shallow copy of current `Hammock` instance as nested child

--- a/test_hammock.py
+++ b/test_hammock.py
@@ -15,6 +15,28 @@ class TestCaseWrest(unittest.TestCase):
     URL = BASE_URL + PATH
 
     @httprettified
+    def test_auth(self):
+        session_headers = {
+            'headers': {'Accept': 'money/bitcoin'},
+            'cookies': {'flavor': 'vanilla'},
+            'auth': ('user', 'pass'),
+            'timeout': 10,
+            'params': {'color':'blue'},
+        }
+        client = Hammock(self.BASE_URL, **session_headers)
+        HTTPretty.register_uri(HTTPretty.GET, self.URL)
+        client.GET('sample', 'path', 'to', 'resource')
+        import copy, requests
+        hdrs = copy.copy(requests.session().headers)
+        hdrs['Accept'] = 'money/bitcoin'
+        self.assertEqual(client._session.headers, hdrs)
+        self.assertEqual(client._session.cookies, {'flavor': 'vanilla'})
+        self.assertEqual(client._session.auth, ('user', 'pass'))
+        self.assertEqual(client._session.timeout, 10)
+        self.assertEqual(client._session.params, {'color': 'blue'})
+        self.assertRaises(ValueError, Hammock, self.BASE_URL, headers=1)
+
+    @httprettified
     def test_methods(self):
         client = Hammock(self.BASE_URL)
         for method in ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']:


### PR DESCRIPTION
This code tries to address the new requests' session issue.
It will setattr() any kwarg value taking care not to overwrite defaults inside session object.
For mapping objects it will fail if supplied value is not a mapping.

Is it ugly? Yes.
Is it bad? Maybe.
Is it better than have no hammock on a 1.x requests installation? Sure it is!
